### PR TITLE
fixed-comment#1

### DIFF
--- a/Clima/Controller/WeatherViewController.swift
+++ b/Clima/Controller/WeatherViewController.swift
@@ -40,7 +40,7 @@ class WeatherViewController: UIViewController {
 extension WeatherViewController: UITextFieldDelegate {
     @IBAction func searchPressed(_ sender: UIButton) {
         searchTextField.endEditing(true)
-        print(searchTextField.text!)
+
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -50,7 +50,7 @@ extension WeatherViewController: UITextFieldDelegate {
     //指定されたテキストフィールドで編集を停止するかどうかを確認してくる
     //ここではsearchTextFieldを指定していないため、引数に渡ってきたtextFieldに対して処理を行う
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        guard textField.text != "" else {
+        guard let text = textField.text, !text.isEmpty else {
             //テキストフィールドが空の場合、編集が終了しない
             textField.placeholder = "Type something"
             return false    


### PR DESCRIPTION
・空文字判定をisEmptyに変更
・消し忘れのprint文を削除
以上を修正しました。
もう一点コメントいただいていた、以下の非同期処理をしていたところですが、
https://github.com/oggysy/Clima-iOS13/blob/master/Clima/Controller/WeatherViewController.swift#L72
DIspatchQueue.main.asyncの記述を消すと、以下の画像のようなエラーになります。
動画内(セクション13 156,Updating the UI by Using the DispatchQueue)でも説明があったのですが、
didUpdateWeather関数が呼ばれるperformRequest関数内で天気情報を取得するAPI通信を行っているため、
以下のエラーを防ぐためにDIspatchQueueを使っていました。
<img width="1154" alt="4ae4af0ff66fd009f5c11fd2c18d5389" src="https://user-images.githubusercontent.com/93628118/217549242-2626a11f-c65a-4f5d-b10d-ebab29e4bfb7.png">